### PR TITLE
Add 'extras' directory to list of dir names excluded from raw data

### DIFF
--- a/bin/collect_dataset_info.py
+++ b/bin/collect_dataset_info.py
@@ -25,6 +25,7 @@ NONRAW_DIRECTORY_NAME_PIECES = [
     "processed",
     "drv",
     "metadata",
+    "extras",
 ]
 
 


### PR DESCRIPTION
One line change, to support new dataset directory structures.