### PR TITLE
Control degree of parallelism from dask in run_background_subtraction

### DIFF
--- a/bin/background_subtraction/run_background_subtraction.py
+++ b/bin/background_subtraction/run_background_subtraction.py
@@ -3,6 +3,7 @@ import json
 import re
 import sys
 from copy import deepcopy
+from multiprocessing.pool import Pool
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -478,12 +479,19 @@ def write_bg_info_to_config(
     return
 
 
-def main(data_dir: Path, pipeline_config_path: Path, cytokit_config_path: Path):
+def main(
+    data_dir: Path,
+    pipeline_config_path: Path,
+    cytokit_config_path: Path,
+    out_base_dir: Path = None,
+):
     """Input images are expected to be stack outputs of cytokit processing
     and have names R001_X001_Y001.tif
     """
-    out_dir = Path("/output/background_subtraction")
-    config_out_dir = Path("/output/config")
+    if out_base_dir is None:
+        out_base_dir = ""  # resulting in output directly below /
+    out_dir = Path(f"{out_base_dir}/output/background_subtraction")
+    config_out_dir = Path(f"{out_base_dir}/output/config")
     make_dir_if_not_exists(out_dir)
     make_dir_if_not_exists(config_out_dir)
 
@@ -588,5 +596,16 @@ if __name__ == "__main__":
         "--pipeline_config_path", type=Path, help="path to pipelineConfig.json file"
     )
     parser.add_argument("--cytokit_config_path", type=Path, help="path to experiment.yaml file")
+    parser.add_argument("--out_base_dir", type=Path, help="base path for output", default=None)
+    parser.add_argument(
+        "--num_concurrent_tasks", type=int, help="How many worker threads", default=None
+    )
     args = parser.parse_args()
-    main(args.data_dir, args.pipeline_config_path, args.cytokit_config_path)
+    if args.num_concurrent_tasks is not None:
+        dask.config.set(pool=Pool(args.num_concurrent_tasks))
+    main(
+        args.data_dir,
+        args.pipeline_config_path,
+        args.cytokit_config_path,
+        out_base_dir=args.out_base_dir,
+    )

--- a/bin/background_subtraction/run_background_subtraction.py
+++ b/bin/background_subtraction/run_background_subtraction.py
@@ -483,15 +483,13 @@ def main(
     data_dir: Path,
     pipeline_config_path: Path,
     cytokit_config_path: Path,
-    out_base_dir: Path = None,
+    out_base_dir: Path = Path("/output"),
 ):
     """Input images are expected to be stack outputs of cytokit processing
     and have names R001_X001_Y001.tif
     """
-    if out_base_dir is None:
-        out_base_dir = ""  # resulting in output directly below /
-    out_dir = Path(f"{out_base_dir}/output/background_subtraction")
-    config_out_dir = Path(f"{out_base_dir}/output/config")
+    out_dir = out_base_dir / "background_subtraction"
+    config_out_dir = out_base_dir / "config"
     make_dir_if_not_exists(out_dir)
     make_dir_if_not_exists(config_out_dir)
 
@@ -596,7 +594,9 @@ if __name__ == "__main__":
         "--pipeline_config_path", type=Path, help="path to pipelineConfig.json file"
     )
     parser.add_argument("--cytokit_config_path", type=Path, help="path to experiment.yaml file")
-    parser.add_argument("--out_base_dir", type=Path, help="base path for output", default=None)
+    parser.add_argument(
+        "--out_base_dir", type=Path, help="base path for output", default="/output"
+    )
     parser.add_argument(
         "--num_concurrent_tasks", type=int, help="How many worker threads", default=None
     )

--- a/steps/ometiff_second_stitching.cwl
+++ b/steps/ometiff_second_stitching.cwl
@@ -11,6 +11,10 @@ inputs:
     type: File
   cytokit_output:
     type: Directory
+  num_concurrent_tasks:
+    label: "Number of parallel CPU jobs"
+    type: int
+    default: 10
 
 outputs:
   stitched_images:
@@ -31,6 +35,10 @@ steps:
         source: slicing_pipeline_config
       cytokit_config:
         source: cytokit_config
+      num_concurrent_tasks:
+        type: int
+        inputBinding:
+        prefix: "--num_concurrent_tasks"
     out:
       - bg_sub_tiles
       - bg_sub_config

--- a/steps/ometiff_second_stitching/background_subtraction.cwl
+++ b/steps/ometiff_second_stitching/background_subtraction.cwl
@@ -26,6 +26,12 @@ inputs:
     inputBinding:
       prefix: "--cytokit_config_path"
 
+  num_concurrent_tasks:
+    type: int
+    default: 10
+    inputBinding:
+      prefix: "--num_concurrent_tasks"
+
 outputs:
   bg_sub_tiles:
     type: Directory


### PR DESCRIPTION
This change includes:
- Modify run_background_subtraction.py to accept an integer --num_concurrent_tasks
- Configure dask to use that number via a process pool
- modify ometiff_second_stitching.cwl and background_subtraction.cwl to provide the parameter

The invocation of background_subtraction.cwl has been tested but the invocation of ometiff_second_stitching and its handoff of --num_concurrent_tasks to the second cwl has not.