### PR TITLE
Pin Anaconda/Miniconda version to py39_4.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -qq update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh \
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh -O /tmp/miniconda.sh \
     && /bin/bash /tmp/miniconda.sh -b -p /opt/conda \
     && rm /tmp/miniconda.sh
 ENV PATH /opt/conda/bin:$PATH


### PR DESCRIPTION
Current versions of Anaconda use Python 3.10, which isn't compatible with some of the package versions we depend on. Until the pipeline code is updated to use newer dependency versions (especially aicsimageio), explicitly specify that we want to use Anaconda based on Python 3.9.